### PR TITLE
Issue #18 Provide public constructor to allow protobuf-net access in …

### DIFF
--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -4,5 +4,5 @@
 [assembly: AssemblyProduct("Time Zone Names")]
 [assembly: AssemblyCopyright("Copyright © Matt Johnson")]
 
-[assembly: AssemblyVersion("2.1.0.*")]
-[assembly: AssemblyInformationalVersion("2.1.0")]
+[assembly: AssemblyVersion("2.1.1.*")]
+[assembly: AssemblyInformationalVersion("2.1.1")]

--- a/TimeZoneNames/TimeZoneData.cs
+++ b/TimeZoneNames/TimeZoneData.cs
@@ -5,7 +5,7 @@ using ProtoBuf;
 namespace TimeZoneNames
 {
     [ProtoContract]
-    internal class TimeZoneData
+    public class TimeZoneData
     {
         [ProtoMember(1)]
         public Dictionary<string, string[]> TzdbZoneCountries { get; } = new Dictionary<string, string[]>();
@@ -42,7 +42,7 @@ namespace TimeZoneNames
     }
 
     [ProtoContract]
-    internal class CldrLanguageData
+    public class CldrLanguageData
     {
         [ProtoMember(1)]
         public TimeZoneValues Formats { get; set; }


### PR DESCRIPTION
PR to allow for Silverlight to use TimeZoneNames without elevated trust. 

From the protobuf-net documentation-

Notes on types

supported:

custom classes that:
    are marked as data-contract
    have a parameterless constructor
    for Silverlight: are public
    many common primitives etc
    single dimension arrays: T[]
    List / IList
    Dictionary / IDictionary
    any type which implements IEnumerable and has an Add(T) method
The code assumes that types will be mutable around the elected members. Accordingly, custom structs are not supported, since they should be immutable.
