### PR TITLE
Fixes #31: Changes TimeZoneData Load() to use JsonSerializer.Create()…

### DIFF
--- a/src/TimeZoneNames/TimeZoneData.cs
+++ b/src/TimeZoneNames/TimeZoneData.cs
@@ -34,7 +34,7 @@ namespace TimeZoneNames
             using (var stream = new GZipStream(compressedStream, CompressionMode.Decompress))
             using (var reader = new StreamReader(stream))
             {
-                var serializer = JsonSerializer.CreateDefault();
+                var serializer = JsonSerializer.Create();
                 return (TimeZoneData)serializer.Deserialize(reader, typeof(TimeZoneData));
             }
         }


### PR DESCRIPTION
… instead of JsonSerializer.CreateDefault() to avoid serializer using custom user settings.